### PR TITLE
Support of DocumentReference resource type

### DIFF
--- a/src/features/documentReferences/DocumentReferenceCard.tsx
+++ b/src/features/documentReferences/DocumentReferenceCard.tsx
@@ -1,0 +1,91 @@
+import React, { useMemo } from "react";
+
+import type { IDocumentReference } from "@ahryman40k/ts-fhir-types/lib/R4";
+import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
+import { Card, CardContent, CardHeader, Typography } from "@mui/material";
+import { makeStyles } from "@mui/styles";
+import { DateTime } from "luxon";
+import { useTranslation } from "react-i18next";
+
+import Tag from "common/components/Tag";
+import ResourceCardActions from "features/resources/ResourceCardActions";
+
+import { TERMINOLOGY_SYSTEM_URL } from "../../constants";
+
+const useStyles = makeStyles((theme) => ({
+  flexContainer: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: theme.spacing(2),
+  },
+  icon: {
+    marginRight: theme.spacing(1),
+    marginLeft: theme.spacing(0.8),
+    fontSize: 20,
+  },
+}));
+
+type DocumentReferenceCardProps = {
+  documentReference: IDocumentReference;
+};
+
+const DocumentReferenceCard = ({
+  documentReference,
+}: DocumentReferenceCardProps): JSX.Element => {
+  const { t } = useTranslation();
+  const classes = useStyles();
+  const { meta, date, resourceType } = documentReference;
+
+  const softwareName = useMemo(
+    () =>
+      meta?.tag?.find(({ system }) => system === TERMINOLOGY_SYSTEM_URL)
+        ?.display,
+    [meta]
+  );
+  const documentReferenceDate = useMemo(
+    () =>
+      date &&
+      DateTime.fromISO(date).toLocaleString(
+        {
+          day: "numeric",
+          month: "long",
+          year: "numeric",
+        },
+        {
+          locale: navigator.language,
+        }
+      ),
+    [date]
+  );
+  return (
+    <Card>
+      <CardHeader
+        disableTypography
+        title={
+          <div className={classes.flexContainer}>
+            <CalendarTodayIcon fontSize="small" className={classes.icon} />
+            <Typography fontSize="0.9rem">
+              {documentReferenceDate ?? "?"}
+            </Typography>
+          </div>
+        }
+        subheader={
+          <div className={classes.flexContainer}>
+            {<Tag value={t(resourceType)} color="#555" />}
+          </div>
+        }
+      />
+      {softwareName && (
+        <CardContent>
+          <Typography variant="caption">
+            {t("software")}: {softwareName}
+          </Typography>
+        </CardContent>
+      )}
+      <ResourceCardActions resource={documentReference} />
+    </Card>
+  );
+};
+
+export default DocumentReferenceCard;

--- a/src/features/resources/ResourceCard.tsx
+++ b/src/features/resources/ResourceCard.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 
 import Tag from "common/components/Tag";
 import ConditionCard from "features/conditions/ConditionCard";
+import DocumentReferenceCard from "features/documentReferences/DocumentReferenceCard";
 import EncounterCard from "features/encounters/EncounterCard";
 
 import ResourceCardActions from "./ResourceCardActions";
@@ -22,6 +23,8 @@ const ResourceCard = ({ resource }: ResourceCardProps): JSX.Element => {
         return <ConditionCard condition={resource} />;
       case "Encounter":
         return <EncounterCard encounter={resource} />;
+      case "DocumentReference":
+        return <DocumentReferenceCard documentReference={resource} />;
 
       default:
         return (

--- a/src/features/resources/ResourceCardActions.tsx
+++ b/src/features/resources/ResourceCardActions.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 
 import type { IResourceList } from "@ahryman40k/ts-fhir-types/lib/R4";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
@@ -7,6 +7,10 @@ import { DefaultTheme, makeStyles } from "@mui/styles";
 import { useTranslation } from "react-i18next";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { monokai } from "react-syntax-highlighter/dist/esm/styles/hljs";
+
+import PDFDialogButton from "common/components/PDFDialogButton";
+
+const PROXY_URL = "https://cors-anywhere.herokuapp.com/";
 
 const useStyles = makeStyles<DefaultTheme, { isExpanded: boolean }>(
   (theme) => ({
@@ -23,6 +27,9 @@ const useStyles = makeStyles<DefaultTheme, { isExpanded: boolean }>(
     syntaxHighlighter: {
       borderRadius: 8,
       fontSize: "0.8rem",
+    },
+    actionContainer: {
+      gap: theme.spacing(2),
     },
   })
 );
@@ -42,15 +49,19 @@ const ResourceCardActions = ({
     setIsExpanded(!isExpanded);
   };
 
+  const pdfUrl = useMemo(() => {
+    if (resource.resourceType === "DocumentReference") {
+      return resource.content?.[0]?.attachment.url;
+    }
+  }, [resource]);
+
   return (
     <>
-      <CardActions>
-        {/* Todo: Uncomment this when a PDF viewing solution is implemented
-         <PDFDialogButton file="https://cors-anywhere.herokuapp.com/https://api.reseauprosante.fr/files/revues/file-648.pdf?id=20200717" /> 
-         */}
+      <CardActions className={classes.actionContainer} disableSpacing>
+        {pdfUrl && <PDFDialogButton file={`${PROXY_URL}${pdfUrl}`} />}
         <Button
           variant="outlined"
-          color="primary"
+          color="secondary"
           className={classes.button}
           onClick={handleExpandMoreClick}
           data-testid={`expand-button-${resource.id}`}

--- a/src/features/resources/utils.ts
+++ b/src/features/resources/utils.ts
@@ -16,6 +16,9 @@ export const sortResourcesByDate = (
     case "CarePlan":
       date1 = DateTime.fromISO(resource1.period?.start ?? "");
       break;
+    case "DocumentReference":
+      date1 = DateTime.fromISO(resource1.date ?? "");
+      break;
 
     default:
       break;
@@ -27,6 +30,9 @@ export const sortResourcesByDate = (
     case "Encounter":
     case "CarePlan":
       date2 = DateTime.fromISO(resource2.period?.start ?? "");
+      break;
+    case "DocumentReference":
+      date2 = DateTime.fromISO(resource2.date ?? "");
       break;
 
     default:

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -15,5 +15,6 @@
   "ipp": "IPP",
   "showFHIRResource": "Show FHIR Resource",
   "hideFHIRResource": "Hide FHIR Resource",
-  "viewDocument": "View document"
+  "viewDocument": "View document",
+  "DocumentReference": "Document"
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -17,5 +17,6 @@
   "ipp": "IPP",
   "showFHIRResource": "Afficher la ressource FHIR",
   "hideFHIRResource": "Cacher la ressource FHIR",
-  "viewDocument": "Afficher le document"
+  "viewDocument": "Afficher le document",
+  "DocumentReference": "Document"
 }


### PR DESCRIPTION
## Fixes

- #39 (doesn't solve it though)

## Description

- Adds support for DocumentReference resource and displays the referenced PDF attachment found at `documentReference.content[0]`

## Capture


https://user-images.githubusercontent.com/12270309/145264363-8384bfc0-b9a8-4bc6-8c45-3a4874f8ca1e.mov



## Definition of Done

- [ ] I followed the [Arkhn Code Book](https://www.notion.so/arkhn/Arkhn-Code-Book-23ac18a8af7343d0a3f61f1c9ef7400c) (I swear!).
- [ ] I have written tests for the code I added or updated.
- [ ] I have updated the documentation according to my changes.
- [ ] I have updated the deployment configuration if needed.
