### PR TITLE
Support Dates/Periods for all listed resources

### DIFF
--- a/src/common/components/DateInfo.tsx
+++ b/src/common/components/DateInfo.tsx
@@ -1,11 +1,15 @@
-import React from "react";
+import React, { useMemo } from "react";
 
+import type { IResourceList } from "@ahryman40k/ts-fhir-types/lib/R4";
 import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
 import { Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
+import { DateTime } from "luxon";
+
+import { getResourceDateOrPeriod } from "features/resources/utils";
 
 type DateInfoProps = {
-  date?: string;
+  resource: IResourceList;
 };
 
 const useStyles = makeStyles((theme) => ({
@@ -22,8 +26,45 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const DateInfo = ({ date }: DateInfoProps): JSX.Element => {
+const DateInfo = ({ resource }: DateInfoProps): JSX.Element => {
   const classes = useStyles();
+  const date = useMemo(() => {
+    const dateOrPeriod = getResourceDateOrPeriod(resource);
+    if (typeof dateOrPeriod === "string") {
+      return DateTime.fromISO(dateOrPeriod).toLocaleString(
+        {
+          day: "numeric",
+          month: "long",
+          year: "numeric",
+        },
+        {
+          locale: navigator.language,
+        }
+      );
+    }
+
+    if (typeof dateOrPeriod === "object") {
+      return `${DateTime.fromISO(dateOrPeriod.start).toLocaleString(
+        {
+          day: "numeric",
+          month: "long",
+          year: "numeric",
+        },
+        {
+          locale: navigator.language,
+        }
+      )} - ${DateTime.fromISO(dateOrPeriod.end).toLocaleString(
+        {
+          day: "numeric",
+          month: "long",
+          year: "numeric",
+        },
+        {
+          locale: navigator.language,
+        }
+      )}`;
+    }
+  }, [resource]);
   return (
     <div className={classes.flexContainer}>
       <CalendarTodayIcon fontSize="small" className={classes.icon} />

--- a/src/features/conditions/ConditionCard.tsx
+++ b/src/features/conditions/ConditionCard.tsx
@@ -3,7 +3,6 @@ import React, { useMemo } from "react";
 import type { ICondition } from "@ahryman40k/ts-fhir-types/lib/R4";
 import { Card, CardContent, CardHeader, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
-import { DateTime } from "luxon";
 import { useTranslation } from "react-i18next";
 
 import DateInfo from "common/components/DateInfo";
@@ -28,7 +27,7 @@ type ConditionCardProps = {
 const ConditionCard = ({ condition }: ConditionCardProps): JSX.Element => {
   const { t } = useTranslation();
   const classes = useStyles();
-  const { code, meta, onsetDateTime, resourceType } = condition;
+  const { code, meta, resourceType } = condition;
   const { codeTag, codeTitle } = useMemo(
     () => ({
       codeTag: `${code?.coding?.[0]?.system}-${code?.coding?.[0]?.code}`,
@@ -42,26 +41,11 @@ const ConditionCard = ({ condition }: ConditionCardProps): JSX.Element => {
         ?.display,
     [meta]
   );
-  const conditionDate = useMemo(
-    () =>
-      onsetDateTime &&
-      DateTime.fromISO(onsetDateTime).toLocaleString(
-        {
-          day: "numeric",
-          month: "long",
-          year: "numeric",
-        },
-        {
-          locale: navigator.language,
-        }
-      ),
-    [onsetDateTime]
-  );
   return (
     <Card>
       <CardHeader
         disableTypography
-        title={<DateInfo date={conditionDate} />}
+        title={<DateInfo resource={condition} />}
         subheader={
           <div className={classes.flexContainer}>
             {<Tag value={resourceType} color="#555" />}

--- a/src/features/documentReferences/DocumentReferenceCard.tsx
+++ b/src/features/documentReferences/DocumentReferenceCard.tsx
@@ -3,7 +3,6 @@ import React, { useMemo } from "react";
 import type { IDocumentReference } from "@ahryman40k/ts-fhir-types/lib/R4";
 import { Card, CardContent, CardHeader, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
-import { DateTime } from "luxon";
 import { useTranslation } from "react-i18next";
 
 import DateInfo from "common/components/DateInfo";
@@ -30,7 +29,7 @@ const DocumentReferenceCard = ({
 }: DocumentReferenceCardProps): JSX.Element => {
   const { t } = useTranslation();
   const classes = useStyles();
-  const { meta, date, resourceType } = documentReference;
+  const { meta, resourceType } = documentReference;
 
   const softwareName = useMemo(
     () =>
@@ -38,26 +37,11 @@ const DocumentReferenceCard = ({
         ?.display,
     [meta]
   );
-  const documentReferenceDate = useMemo(
-    () =>
-      date &&
-      DateTime.fromISO(date).toLocaleString(
-        {
-          day: "numeric",
-          month: "long",
-          year: "numeric",
-        },
-        {
-          locale: navigator.language,
-        }
-      ),
-    [date]
-  );
   return (
     <Card>
       <CardHeader
         disableTypography
-        title={<DateInfo date={documentReferenceDate} />}
+        title={<DateInfo resource={documentReference} />}
         subheader={
           <div className={classes.flexContainer}>
             {<Tag value={resourceType} color="#555" />}

--- a/src/features/encounters/EncounterCard.tsx
+++ b/src/features/encounters/EncounterCard.tsx
@@ -3,7 +3,6 @@ import React, { useMemo } from "react";
 import type { IEncounter } from "@ahryman40k/ts-fhir-types/lib/R4";
 import { Card, CardContent, CardHeader, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
-import { DateTime } from "luxon";
 import { useTranslation } from "react-i18next";
 
 import DateInfo from "common/components/DateInfo";
@@ -28,36 +27,7 @@ type EncounterCardProps = {
 const EncounterCard = ({ encounter }: EncounterCardProps): JSX.Element => {
   const { t } = useTranslation();
   const classes = useStyles();
-  const { period, meta, location, resourceType } = encounter;
-  const { startPeriod, endPeriod } = useMemo(
-    () => ({
-      startPeriod:
-        period?.start &&
-        DateTime.fromISO(period.start).toLocaleString(
-          {
-            day: "numeric",
-            month: "long",
-            year: "numeric",
-          },
-          {
-            locale: navigator.language,
-          }
-        ),
-      endPeriod:
-        period?.end &&
-        DateTime.fromISO(period.end).toLocaleString(
-          {
-            day: "numeric",
-            month: "long",
-            year: "numeric",
-          },
-          {
-            locale: navigator.language,
-          }
-        ),
-    }),
-    [period]
-  );
+  const { meta, location, resourceType } = encounter;
   const softwareName = useMemo(
     () =>
       meta?.tag?.find(({ system }) => system === TERMINOLOGY_SYSTEM_URL)
@@ -72,16 +42,7 @@ const EncounterCard = ({ encounter }: EncounterCardProps): JSX.Element => {
     <Card>
       <CardHeader
         disableTypography
-        title={
-          <DateInfo
-            date={
-              period &&
-              [startPeriod, endPeriod]
-                .filter((periodValue) => !!periodValue)
-                .join(" - ")
-            }
-          />
-        }
+        title={<DateInfo resource={encounter} />}
         subheader={
           <div className={classes.flexContainer}>
             <Tag value={resourceType} color="#555" />

--- a/src/features/resources/ResourceCard.tsx
+++ b/src/features/resources/ResourceCard.tsx
@@ -29,7 +29,7 @@ const ResourceCard = ({ resource }: ResourceCardProps): JSX.Element => {
         return (
           <Card>
             <CardHeader
-              title={<DateInfo />}
+              title={<DateInfo resource={resource} />}
               subheader={<Tag value={resource.resourceType} color="#555" />}
             />
             <ResourceCardActions resource={resource} />

--- a/src/features/resources/utils.ts
+++ b/src/features/resources/utils.ts
@@ -1,42 +1,125 @@
 import type { IResourceList } from "@ahryman40k/ts-fhir-types/lib/R4";
 import { DateTime } from "luxon";
 
-export const sortResourcesByDate = (
-  resource1: IResourceList,
-  resource2: IResourceList
-): number => {
-  let date1: DateTime | null = null;
-  let date2: DateTime | null = null;
-
-  switch (resource1.resourceType) {
-    case "Condition":
-      date1 = DateTime.fromISO(resource1.onsetDateTime ?? "");
-      break;
-    case "Encounter":
-    case "CarePlan":
-      date1 = DateTime.fromISO(resource1.period?.start ?? "");
-      break;
+export const getResourceDateOrPeriod = (
+  resource: IResourceList
+): string | { start: string; end: string } | undefined => {
+  let start: string | undefined;
+  let end: string | undefined;
+  switch (resource.resourceType) {
+    case "AdverseEvent":
     case "DocumentReference":
-      date1 = DateTime.fromISO(resource1.date ?? "");
+    case "FamilyMemberHistory":
+      start = resource.date;
+      break;
+    case "AllergyIntolerance":
+    case "Condition":
+      if (resource.onsetPeriod) {
+        start = resource.onsetPeriod.start;
+        end = resource.onsetPeriod.end;
+      } else {
+        start = resource.onsetDateTime;
+      }
+      break;
+    case "CarePlan":
+    case "Encounter":
+    case "EpisodeOfCare":
+    case "Flag":
+      start = resource.period?.start;
+      end = resource.period?.end;
+      break;
+    case "ClinicalImpression":
+    case "DiagnosticReport":
+    case "MedicationAdministration":
+    case "MedicationStatement":
+    case "Observation":
+      if (resource.effectivePeriod) {
+        start = resource.effectivePeriod.start;
+        end = resource.effectivePeriod.end;
+      } else {
+        start = resource.effectiveDateTime;
+      }
+      break;
+    case "Consent":
+      start = resource.dateTime;
+      break;
+    case "DetectedIssue":
+      start = resource.identifiedDateTime;
+      break;
+    case "DeviceRequest":
+    case "MedicationRequest":
+    case "ServiceRequest":
+      start = resource.authoredOn;
+      break;
+    case "Immunization":
+      start = resource.occurrenceDateTime;
+      break;
+    case "RiskAssessment":
+      if (resource.occurrencePeriod) {
+        start = resource.occurrencePeriod.start;
+        end = resource.occurrencePeriod.end;
+      } else {
+        start = resource.occurrenceDateTime;
+      }
+      break;
+    case "Media":
+      if (resource.createdPeriod) {
+        start = resource.createdPeriod.start;
+        end = resource.createdPeriod.end;
+      } else {
+        start = resource.createdDateTime;
+      }
+      break;
+    case "MedicationDispense":
+      start = resource.whenHandedOver;
+      break;
+    case "Procedure":
+      if (resource.performedPeriod) {
+        start = resource.performedPeriod.start;
+        end = resource.performedPeriod.end;
+      } else {
+        start = resource.performedDateTime;
+      }
+      break;
+    case "QuestionnaireResponse":
+      start = resource.authored;
+      break;
+    case "Specimen":
+      if (resource.collection?.collectedPeriod) {
+        start = resource.collection?.collectedPeriod.start;
+        end = resource.collection?.collectedPeriod.end;
+      } else {
+        start = resource.collection?.collectedDateTime;
+      }
       break;
 
     default:
       break;
   }
-  switch (resource2.resourceType) {
-    case "Condition":
-      date2 = DateTime.fromISO(resource2.onsetDateTime ?? "");
-      break;
-    case "Encounter":
-    case "CarePlan":
-      date2 = DateTime.fromISO(resource2.period?.start ?? "");
-      break;
-    case "DocumentReference":
-      date2 = DateTime.fromISO(resource2.date ?? "");
-      break;
 
-    default:
-      break;
+  return start && end ? { start, end } : start;
+};
+
+export const sortResourcesByDate = (
+  resource1: IResourceList,
+  resource2: IResourceList
+): number => {
+  let date1: DateTime | undefined;
+  let date2: DateTime | undefined;
+
+  const dateOrPeriod1 = getResourceDateOrPeriod(resource1);
+  const dateOrPeriod2 = getResourceDateOrPeriod(resource2);
+
+  if (typeof dateOrPeriod1 === "string") {
+    date1 = DateTime.fromISO(dateOrPeriod1);
+  } else if (typeof dateOrPeriod1 === "object") {
+    date1 = DateTime.fromISO(dateOrPeriod1.start);
+  }
+
+  if (typeof dateOrPeriod2 === "string") {
+    date2 = DateTime.fromISO(dateOrPeriod2);
+  } else if (typeof dateOrPeriod2 === "object") {
+    date2 = DateTime.fromISO(dateOrPeriod2.start);
   }
 
   if (date1 && date2) {


### PR DESCRIPTION
## Fixes

- Fixes #50 

## Description

- Supports all resources returned by `$everything`.
- Sorts all resource cards by date or start date when `Period` is defined.

## Definition of Done

- [x] I followed the [Arkhn Code Book](https://www.notion.so/arkhn/Arkhn-Code-Book-23ac18a8af7343d0a3f61f1c9ef7400c) (I swear!).
- [x] I have written tests for the code I added or updated.
- [x] I have updated the documentation according to my changes.
- [x] I have updated the deployment configuration if needed.
